### PR TITLE
feat: Mise en place des CRUD

### DIFF
--- a/src/main/java/repositories/AbstractRepository.java
+++ b/src/main/java/repositories/AbstractRepository.java
@@ -1,0 +1,113 @@
+package repositories;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+import javax.persistence.criteria.CriteriaQuery;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+
+import dao.HibernateUtil;
+
+public abstract class AbstractRepository<T, K extends Serializable> {
+
+	protected Class<T> clazz;
+
+	protected AbstractRepository(final Class<T> inClazz) {
+		clazz = inClazz;
+
+	}
+
+	public List<T> findAll() {
+
+		final Session session = getSession();
+
+		final Transaction transaction = session.beginTransaction();
+
+		final List<T> result = findAll(session);
+
+		transaction.commit();
+
+		return result;
+	}
+
+	public List<T> findAll(final Session session) {
+
+		final CriteriaQuery<T> cq = session.getCriteriaBuilder().createQuery(clazz);
+		cq.from(clazz);
+
+		return session.createQuery(cq).getResultList();
+	}
+
+	public T findById(final K id) {
+		final Session session = getSession();
+
+		final Transaction transaction = session.beginTransaction();
+
+		final T result = findById(id, session);
+
+		transaction.commit();
+
+		return result;
+	}
+
+	public T findById(final K id, final Session session) {
+		T result = null;
+
+		if (Objects.nonNull(id)) {
+
+			result = session.get(clazz, id);
+		}
+
+		return result;
+	}
+
+	public void update(final T entity) {
+		final Session session = getSession();
+
+		final Transaction transaction = session.beginTransaction();
+
+		update(entity, session);
+
+		transaction.commit();
+	}
+
+	public void update(final T entity, final Session session) {
+		session.update(entity);
+	}
+
+	public void create(final T entity) {
+		final Session session = getSession();
+
+		final Transaction transaction = session.beginTransaction();
+
+		create(entity, session);
+
+		transaction.commit();
+	}
+
+	public void create(final T entity, final Session session) {
+		session.save(entity);
+	}
+
+	public void delete(final T entity) {
+		final Session session = getSession();
+
+		final Transaction transaction = session.beginTransaction();
+
+		delete(entity, session);
+
+		transaction.commit();
+	}
+
+	public void delete(final T entity, final Session session) {
+		session.delete(entity);
+	}
+
+	protected Session getSession() {
+		return HibernateUtil.getSessionFactory().getCurrentSession();
+	}
+
+}

--- a/src/main/java/repositories/ArticleRepository.java
+++ b/src/main/java/repositories/ArticleRepository.java
@@ -1,0 +1,11 @@
+package repositories;
+
+import models.Article;
+
+public class ArticleRepository extends AbstractRepository<Article, Integer> {
+
+	public ArticleRepository() {
+		super(Article.class);
+	}
+
+}

--- a/src/main/java/repositories/CategorieRepository.java
+++ b/src/main/java/repositories/CategorieRepository.java
@@ -1,0 +1,11 @@
+package repositories;
+
+import models.Categorie;
+
+public class CategorieRepository extends AbstractRepository<Categorie, Integer> {
+
+	public CategorieRepository() {
+		super(Categorie.class);
+	}
+
+}

--- a/src/main/java/repositories/ComposerRepository.java
+++ b/src/main/java/repositories/ComposerRepository.java
@@ -1,0 +1,12 @@
+package repositories;
+
+import models.Composer;
+import models.keys.ComposerKey;
+
+public class ComposerRepository extends AbstractRepository<Composer, ComposerKey> {
+
+	public ComposerRepository() {
+		super(Composer.class);
+	}
+
+}

--- a/src/main/java/repositories/ConcernerRepository.java
+++ b/src/main/java/repositories/ConcernerRepository.java
@@ -1,0 +1,12 @@
+package repositories;
+
+import models.Concerner;
+import models.keys.ConcernerKey;
+
+public class ConcernerRepository extends AbstractRepository<Concerner, ConcernerKey> {
+
+	public ConcernerRepository() {
+		super(Concerner.class);
+	}
+
+}

--- a/src/main/java/repositories/ContenirRepository.java
+++ b/src/main/java/repositories/ContenirRepository.java
@@ -1,0 +1,12 @@
+package repositories;
+
+import models.Contenir;
+import models.keys.ContenirKey;
+
+public class ContenirRepository extends AbstractRepository<Contenir, ContenirKey> {
+
+	public ContenirRepository() {
+		super(Contenir.class);
+	}
+
+}

--- a/src/main/java/repositories/CreneauRepository.java
+++ b/src/main/java/repositories/CreneauRepository.java
@@ -1,0 +1,11 @@
+package repositories;
+
+import models.Creneau;
+
+public class CreneauRepository extends AbstractRepository<Creneau, Integer> {
+
+	public CreneauRepository() {
+		super(Creneau.class);
+	}
+
+}

--- a/src/main/java/repositories/ListeDeCourseRepository.java
+++ b/src/main/java/repositories/ListeDeCourseRepository.java
@@ -1,0 +1,11 @@
+package repositories;
+
+import models.ListeDeCourse;
+
+public class ListeDeCourseRepository extends AbstractRepository<ListeDeCourse, Integer> {
+
+	public ListeDeCourseRepository() {
+		super(ListeDeCourse.class);
+	}
+
+}

--- a/src/main/java/repositories/MagasinRepository.java
+++ b/src/main/java/repositories/MagasinRepository.java
@@ -1,0 +1,11 @@
+package repositories;
+
+import models.Magasin;
+
+public class MagasinRepository extends AbstractRepository<Magasin, Integer> {
+
+	public MagasinRepository() {
+		super(Magasin.class);
+	}
+
+}

--- a/src/main/java/repositories/PanierRepository.java
+++ b/src/main/java/repositories/PanierRepository.java
@@ -1,0 +1,11 @@
+package repositories;
+
+import models.Panier;
+
+public class PanierRepository extends AbstractRepository<Panier, Integer> {
+
+	public PanierRepository() {
+		super(Panier.class);
+	}
+
+}

--- a/src/main/java/repositories/PostItRepository.java
+++ b/src/main/java/repositories/PostItRepository.java
@@ -1,0 +1,11 @@
+package repositories;
+
+import models.PostIt;
+
+public class PostItRepository extends AbstractRepository<PostIt, Integer> {
+
+	public PostItRepository() {
+		super(PostIt.class);
+	}
+
+}

--- a/src/main/java/repositories/RayonRepository.java
+++ b/src/main/java/repositories/RayonRepository.java
@@ -1,0 +1,11 @@
+package repositories;
+
+import models.Rayon;
+
+public class RayonRepository extends AbstractRepository<Rayon, Integer> {
+
+	public RayonRepository() {
+		super(Rayon.class);
+	}
+
+}

--- a/src/main/java/repositories/RecetteRepository.java
+++ b/src/main/java/repositories/RecetteRepository.java
@@ -1,0 +1,11 @@
+package repositories;
+
+import models.Recette;
+
+public class RecetteRepository extends AbstractRepository<Recette, Integer> {
+
+	public RecetteRepository() {
+		super(Recette.class);
+	}
+
+}

--- a/src/main/java/repositories/SousCategorieRepository.java
+++ b/src/main/java/repositories/SousCategorieRepository.java
@@ -1,0 +1,11 @@
+package repositories;
+
+import models.SousCategorie;
+
+public class SousCategorieRepository extends AbstractRepository<SousCategorie, Integer> {
+
+	public SousCategorieRepository() {
+		super(SousCategorie.class);
+	}
+
+}

--- a/src/main/java/repositories/StockerRepository.java
+++ b/src/main/java/repositories/StockerRepository.java
@@ -1,0 +1,12 @@
+package repositories;
+
+import models.Stocker;
+import models.keys.StockerKey;
+
+public class StockerRepository extends AbstractRepository<Stocker, StockerKey> {
+
+	public StockerRepository() {
+		super(Stocker.class);
+	}
+
+}

--- a/src/main/java/repositories/UtilisateurRepository.java
+++ b/src/main/java/repositories/UtilisateurRepository.java
@@ -1,0 +1,11 @@
+package repositories;
+
+import models.Utilisateur;
+
+public class UtilisateurRepository extends AbstractRepository<Utilisateur, Integer> {
+
+	public UtilisateurRepository() {
+		super(Utilisateur.class);
+	}
+
+}


### PR DESCRIPTION
Cette PR est dépendante de la #16 .

Elle contient une approche à la "Spring Boot" mais en nous laissant la main sur les sessions et les entités.

L'idée étant de cloisonner la responsabilité de CRUD à un Repository concernant une seule entité. (viendra ensuite les soucis des liaisons avec les tables d'association, mais cela peut venir dans un second temps.

Dans ces repositories, on pourra Créer Récupérer Modifier et Supprimer des entités via leur repository en utilisateur leur méthodes 
- `create()`
- `get()`
- `update()`
- `delete()`

L'idée étant de gagner du temps pour la suite.

🛑 Hésitez pas à mettre si vous ne voulez pas adopter cette approche car trop technique ou trop complexe. C'est notre projet :)

🪧Pas encore de javadoc mais cette PR pourrait ne pas être mergée. Dans l'attente de discussion